### PR TITLE
Level 3 - Json Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,274 @@
-# Popmenu Challenge — (Rails + PostgreSQL)
+# Popmenu Challenge — Rails + PostgreSQL (Levels 1 → 3)
 
-This repository contains a minimal, production-ready **Level 1** implementation for the Popmenu coding challenge.
-Stack: **Ruby on Rails + PostgreSQL + RSpec**.
+A production-ready implementation of the Popmenu coding challenge, delivered iteratively across **Level 1, Level 2, and Level 3**.
+Stack: **Ruby on Rails** · **PostgreSQL** · **RSpec**.
 
-## What Level 1 Includes
+## Quickstart
 
-* **Models:** `Menu` (has many) → `MenuItem`
-* **Validations:** presence/format + **unique** `MenuItem.name` **scoped to menu**
-* **DB Constraints:** `NOT NULL`, defaults, indexes (including unique composite index)
-* **Controllers/Routes:** CRUD for menus and menu items; list & filter endpoints
-* **Seeds:** sample data for quick inspection
-* **Tests:** RSpec model and request specs (with FactoryBot, Shoulda)
+### Requirements
 
-## What Level 2 Includes
+* Ruby **3.2+** (works on 3.3.x)
+* Rails **7.1+**
+* PostgreSQL **13+**
 
-* **Models & Relationships:**
-  * New **`Restaurant`** model
-  * **`Menu`** now `belongs_to :restaurant`
-  * **`MenuItem`** now `belongs_to :restaurant` *(no longer belongs to a menu)*
-  * **`Menu` ↔ `MenuItem`** is **many-to-many** via **`MenuItemization`**
+### Setup
 
-* **Uniqueness Rule:**
-  * **`MenuItem.name`** is **unique per restaurant** *(scoped by `restaurant_id`)*
-  * If you prefer **global** uniqueness, enforce a unique index on **`menu_items.name`** alone
+```bash
+# 1) Install gems
+bundle install
 
-* **Controllers/Routes (Endpoints):**
-  * **Create/List Menus** within a restaurant
-  * **Create/List Items** within a restaurant
-  * **Link / Unlink** existing items to menus
+# 2) Configure database (adjust username/password as needed)
+# config/database.yml expects:
+#   PGUSER=popmenu
+#   PGPASSWORD=popmenu
+# or edit the file to match your local setup
 
-* **Tests:**
-  * RSpec coverage (**models + requests**) aligned with the new Level 2 domain
+# Optionally create a local DB role:
+psql -U postgres -c "CREATE ROLE popmenu WITH LOGIN PASSWORD 'popmenu';"
+psql -U postgres -c "ALTER ROLE popmenu CREATEDB;"
 
+# 3) Create and migrate databases
+bin/rails db:create
+bin/rails db:migrate
 
-## Next Steps (for Level 2+)
+# 4) (Optional) Seed sample data
+bin/rails db:seed
 
-* Introduce `Restaurant` and evolve relationships (e.g., one restaurant with multiple menus; item reuse rules).
-* Add pagination, sorting, and more filters.
-* Add serializers (e.g., Blueprinter/AMS) for response stability.
-* Add import endpoints/services and CLI tasks (Level 3).
+# 5) Run the server
+bin/rails server
+# API at http://localhost:3000
+```
 
 ---
 
+## Domain by Level
+
+### Level 1
+
+**Goal:** Minimal menu system.
+
+* **Models:** `Menu` (has many) → `MenuItem`
+* **Validations:** presence + uniqueness for `MenuItem.name` **scoped to menu**
+* **DB constraints:** `NOT NULL`, defaults, indexes, and a **composite unique index** to prevent duplicates within a menu
+* **Controllers/Routes:** CRUD for menus and items; list & filter endpoints
+* **Seeds & Tests:** seeds for quick inspection; RSpec model & request specs
+
+---
+
+### Level 2
+
+**Goal:** Multiple menus per restaurant; reusable items.
+
+* **New model:** `Restaurant`
+* **Menu** now `belongs_to :restaurant`
+* **MenuItem** now `belongs_to :restaurant` (no longer belongs to a menu)
+* **Menu ↔ MenuItem** becomes **many-to-many** via `MenuItemization`
+* **Uniqueness rule:** `MenuItem.name` is **unique per restaurant**
+* **Endpoints:**
+
+  * Create/list **menus within a restaurant**
+  * Create/list **items within a restaurant**
+  * **Link / unlink** existing items to menus
+* **Backfill migration:** moves Level 1 data safely, de-duplicates names if needed, and re-enables unique indexes
+* **Tests:** model specs & request specs (including link/unlink)
+
+**ER Diagram (Level 2)**
+
+```
+Restaurant (1) ── (N) Menu
+Restaurant (1) ── (N) MenuItem
+Menu (N) ── (N) MenuItem   via MenuItemization
+```
+
+> Migration tip used here: temporarily drop unique index on `menus(restaurant_id, name)` for backfill; re-add it after cleaning duplicates.
+
+---
+
+### Level 3
+
+**Goal:** JSON import endpoint + conversion tool; per-menu prices.
+
+* **HTTP endpoint** that accepts **JSON** and/or **file upload**:
+
+  * `POST /imports/restaurant_json` with `multipart/form-data` (`file`) **or**
+  * `application/json` body `{ "data": { ... } }`
+* **Importer service** (`Importers::RestaurantDataImporter`) that:
+
+  * Parses restaurants/menus/items from JSON
+  * Accepts items under `menu_items` **or** `dishes`
+  * Deduplicates repeated item names in the **same menu** within the payload
+  * Upserts **Restaurant**, **Menu**, **MenuItem**
+  * **Links items to menus** via `MenuItemization`
+  * Returns a **log per item** and an overall `success/fail`
+* **Per-menu price support:** add `price_cents` to **`menu_itemizations`** so the same item (e.g., “Burger”) can cost differently in **lunch** vs **dinner**
+* **CLI task:** `rake import:restaurants[path/to/restaurant_data.json]`
+* **Robust logging & exception handling**
+* **Tests:** service spec + endpoint (request) spec
+
+---
+
+## Examples (cURL)
+
+```bash
+# Create a restaurant
+curl -X POST http://localhost:3000/restaurants \
+ -H "Content-Type: application/json" \
+ -d '{"restaurant":{"name":"Pizzeria Roma","slug":"pizzeria-roma"}}'
+
+# Create menus within a restaurant
+curl -X POST http://localhost:3000/restaurants/1/menus \
+ -H "Content-Type: application/json" \
+ -d '{"menu":{"name":"Lunch","description":"Daytime specials"}}'
+
+curl -X POST http://localhost:3000/restaurants/1/menus \
+ -H "Content-Type: application/json" \
+ -d '{"menu":{"name":"Dinner","description":"Evening menu"}}'
+
+# Create items within a restaurant
+curl -X POST http://localhost:3000/restaurants/1/menu_items \
+ -H "Content-Type: application/json" \
+ -d '{"menu_item":{"name":"Burger","price_cents":1200,"available":true}}'
+
+curl -X POST http://localhost:3000/restaurants/1/menu_items \
+ -H "Content-Type: application/json" \
+ -d '{"menu_item":{"name":"Large Salad","price_cents":800,"available":true}}'
+
+# Link items to menus (re-use across multiple menus)
+curl -X POST http://localhost:3000/restaurants/1/menus/1/menu_items/1/link
+curl -X POST http://localhost:3000/restaurants/1/menus/2/menu_items/1/link
+curl -X POST http://localhost:3000/restaurants/1/menus/2/menu_items/2/link
+
+# Show a menu (includes per-menu price)
+curl http://localhost:3000/menus/2
+
+# Unlink an item
+curl -X DELETE http://localhost:3000/restaurants/1/menus/2/menu_items/2/unlink
+
+# List items with filters
+curl "http://localhost:3000/restaurants/1/menu_items?available=true&q=burger"
+```
+
+**Responses** are JSON. Validation failures return **422 Unprocessable Content** with error messages.
+
+---
+
+## Importer (HTTP & CLI)
+
+### HTTP Endpoint (Level 3)
+
+`POST /imports/restaurant_json`
+
+* **multipart/form-data** with a `file` (JSON), **or**
+* **application/json** body:
+
+  ```json
+  { "data": { "restaurants": [ ... ] } }
+  ```
+
+**Example payload** (shortened from the challenge/mocked sample; supports `menu_items` or `dishes` arrays under a menu):
+
+```json
+{
+  "restaurants": [
+    {
+      "name": "Poppo's Cafe",
+      "menus": [
+        {
+          "name": "lunch",
+          "menu_items": [
+            { "name": "Burger", "price": 9.00 },
+            { "name": "Small Salad", "price": 5.00 }
+          ]
+        },
+        {
+          "name": "dinner",
+          "menu_items": [
+            { "name": "Burger", "price": 15.00 },
+            { "name": "Large Salad", "price": 8.00 }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+### CLI Task
+
+```bash
+# Pretty-prints the same JSON result (and exits non-zero on failure)
+rake import:restaurants[path/to/restaurant_data.json]
+```
+## Testing
+
+```bash
+# Prepare test DB
+bin/rails db:environment:set RAILS_ENV=test
+bin/rails db:test:prepare
+
+# Run the suite
+bundle exec rspec
+```
+
+## Design Decisions & Assumptions
+
+* **Prices as integers (`*_cents`)** to avoid floating-point rounding issues.
+* **Per-menu price** lives on the **join** (`menu_itemizations.price_cents`).
+  `menu_items.price_cents` serves as an optional default/legacy value.
+* **Uniqueness scope** for `MenuItem.name` is **per restaurant**; different restaurants may have items with the same name.
+  (Switch to global uniqueness by enforcing a unique index on `menu_items.name` alone.)
+* **Idempotent imports**: upserts by `(restaurant.slug)`, `(restaurant_id, menu.name)`, and `(restaurant_id, item.name)`.
+* **Backfill safety (Level 2)**: temporarily drop `menus(restaurant_id, name)` unique index during backfill; de-duplicate then re-add.
+* **Logging & errors**: the importer returns a structured log list plus `success`/`errors_count`, and continues processing after per-item errors.
+
+## Project Structure
+
+```
+app/
+  controllers/
+    imports_controller.rb
+    menu_items_controller.rb
+    menus_controller.rb
+    restaurants_controller.rb
+  models/
+    menu.rb
+    menu_item.rb
+    menu_itemization.rb
+    restaurant.rb
+  services/
+    importers/
+      restaurant_data_importer.rb
+config/
+  routes.rb
+db/
+  migrate/
+  seeds.rb
+lib/
+  tasks/
+    import.rake
+spec/
+  fixtures/
+    files/
+      restaurant_data.json
+  factories/
+    menu_itemizations.rb
+    menu_items.rb
+    menus.rb
+    restaurants.rb
+  models/
+    menu_item_spec.rb
+    menu_itemization_spec.rb
+    menu_spec.rb
+    restaurant_spec.rb
+  requests/
+    imports_spec.rb
+    menu_items_level2_spec.rb
+    menus_level2_spec.rb
+    restaurants_spec.rb
+  services/
+    importers/
+      restaurant_data_importer_spec.rb
+```
 ## License
 
-For interview/evaluation purposes. Use freely for this challenge.
+For interview/evaluation purposes

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -13,7 +13,7 @@ class ImportsController < ApplicationController
 
     render json: result, status: status
   rescue ActionController::ParameterMissing => e
-    render json: { success: false, errors_count: 1, logs: [{ scope: "import", action: "error", errors: [e.message] }] },
+    render json: { success: false, errors_count: 1, logs: [ { scope: "import", action: "error", errors: [ e.message ] } ] },
            status: :unprocessable_content
   end
 end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -12,7 +12,7 @@ class ImportsController < ApplicationController
     result = Importers::RestaurantDataImporter.new(payload: payload).call
     render json: result, status: (result[:success] ? :ok : :unprocessable_content)
   rescue ActionController::ParameterMissing => e
-    render json: { success: false, errors_count: 1, logs: [{ scope: "import", action: "error", errors: [e.message] }] },
+    render json: { success: false, errors_count: 1, logs: [ { scope: "import", action: "error", errors: [ e.message ] } ] },
            status: :unprocessable_content
   end
 
@@ -27,8 +27,8 @@ class ImportsController < ApplicationController
           menus: [
             :name, :description,
             # support either "menu_items" or "dishes"
-            { menu_items: [:name, :description, :price, :price_cents, :available] },
-            { dishes:     [:name, :description, :price, :price_cents, :available] }
+            { menu_items: [ :name, :description, :price, :price_cents, :available ] },
+            { dishes:     [ :name, :description, :price, :price_cents, :available ] }
           ]
         }
       ]

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -5,7 +5,7 @@ class ImportsController < ApplicationController
       if params[:file].present?
         JSON.parse(params[:file].read)
       else
-        params.require(:data).permit.to_h # wait { data: {...} }
+        params.require(:data).permit!.to_h # wait { data: {...} }
       end
 
     result = Importers::RestaurantDataImporter.new(payload: payload).call

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,0 +1,19 @@
+class ImportsController < ApplicationController
+  # POST /imports/restaurant_json
+  def restaurant_json
+    payload =
+      if params[:file].present?
+        JSON.parse(params[:file].read)
+      else
+        params.require(:data).permit!.to_h # espera { data: {...} }
+      end
+
+    result = Importers::RestaurantDataImporter.new(payload: payload).call
+    status = result[:success] ? :ok : :unprocessable_content
+
+    render json: result, status: status
+  rescue ActionController::ParameterMissing => e
+    render json: { success: false, errors_count: 1, logs: [{ scope: "import", action: "error", errors: [e.message] }] },
+           status: :unprocessable_content
+  end
+end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -5,7 +5,7 @@ class ImportsController < ApplicationController
       if params[:file].present?
         JSON.parse(params[:file].read)
       else
-        params.require(:data).permit!.to_h # espera { data: {...} }
+        params.require(:data).permit.to_h # wait { data: {...} }
       end
 
     result = Importers::RestaurantDataImporter.new(payload: payload).call

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -26,11 +26,29 @@ class MenusController < ApplicationController
 
   # GET /menus/:id
   def show
-    render json: @menu.as_json(
-      only: [ :id, :restaurant_id, :name, :description, :created_at, :updated_at ],
-      include: { menu_items: { only: [ :id, :restaurant_id, :name, :description, :price_cents, :available ] } }
-    )
+    items = @menu.menu_itemizations.includes(:menu_item).order(:position).map do |mi|
+      item = mi.menu_item
+      {
+        id: item.id,
+        restaurant_id: item.restaurant_id,
+        name: item.name,
+        description: item.description,
+        price_cents: mi.price_cents || item.price_cents,
+        available: item.available
+      }
+    end
+
+    render json: {
+      id: @menu.id,
+      restaurant_id: @menu.restaurant_id,
+      name: @menu.name,
+      description: @menu.description,
+      created_at: @menu.created_at,
+      updated_at: @menu.updated_at,
+      menu_items: items
+    }
   end
+
 
   # POST /restaurants/:restaurant_id/menus/:id/menu_items/:menu_item_id/link
   def link_item

--- a/app/models/menu_itemization.rb
+++ b/app/models/menu_itemization.rb
@@ -3,4 +3,6 @@ class MenuItemization < ApplicationRecord
   belongs_to :menu_item
 
   validates :menu_id, uniqueness: { scope: :menu_item_id }
+  validates :price_cents,
+            numericality: { greater_than_or_equal_to: 0, allow_nil: true }
 end

--- a/app/services/importers/restaurant_data_importer.rb
+++ b/app/services/importers/restaurant_data_importer.rb
@@ -1,0 +1,156 @@
+module Importers
+  class RestaurantDataImporter
+    # {
+    #   success: true/false,
+    #   errors_count: Integer,
+    #   logs: [ {scope:, action:, ...}, ... ]
+    # }
+    def initialize(payload:, logger: Rails.logger)
+      @payload = payload
+      @logger  = logger
+      @logs    = []
+      @errors  = 0
+    end
+
+    def call
+      restaurants = Array(@payload["restaurants"])
+      if restaurants.empty?
+        log_error("import", nil, ["No restaurants found in payload"])
+        return result(false)
+      end
+
+      restaurants.each_with_index do |rest_json, r_idx|
+        import_one_restaurant(rest_json, r_idx)
+      end
+
+      result(@errors.zero?)
+    rescue => e
+      @logger.error(e.full_message)
+      log_error("import", nil, [e.message])
+      result(false)
+    end
+
+    private
+
+    def import_one_restaurant(rest_json, r_idx)
+      ActiveRecord::Base.transaction do
+        restaurant = upsert_restaurant!(rest_json)
+
+        Array(rest_json["menus"]).each_with_index do |menu_json, m_idx|
+          menu = upsert_menu!(restaurant, menu_json)
+
+          # Itens podem vir como "menu_items" ou "dishes"
+          items = Array(menu_json["menu_items"]) + Array(menu_json["dishes"])
+          next if items.empty?
+
+          # Evitar processar duplicados no mesmo menu pelo mesmo nome
+          seen_names = Set.new
+
+          items.each_with_index do |item_json, i_idx|
+            name = item_json["name"].to_s.strip
+            price = item_json["price"]
+
+            if name.blank?
+              log_error("menu_item", nil, ["Missing name"], menu:, restaurant:)
+              next
+            end
+
+            # se o mesmo nome aparecer repetido dentro do mesmo menu no payload
+            if seen_names.include?(name.downcase)
+              @logs << {
+                scope: "menu_item",
+                name: name,
+                action: "skipped_duplicate_in_payload",
+                restaurant: restaurant.name,
+                menu: menu.name
+              }
+              next
+            end
+            seen_names.add(name.downcase)
+
+            begin
+              item = upsert_menu_item!(restaurant, name, item_json)
+
+              # Vincula ao menu com preço específico do menu (override)
+              link_item_to_menu!(menu, item, price, i_idx)
+            rescue ActiveRecord::RecordInvalid => e
+              log_error("menu_item", name, e.record.errors.full_messages, menu:, restaurant:)
+            rescue => e
+              log_error("menu_item", name, [e.message], menu:, restaurant:)
+            end
+          end
+        end
+      end
+    end
+
+    def upsert_restaurant!(h)
+      name = h["name"].to_s.strip
+      slug = name.parameterize
+      r = Restaurant.find_or_initialize_by(slug: slug)
+      r.name = name.presence || "Unnamed Restaurant"
+      r.save!
+      @logs << { scope: "restaurant", name: r.name, action: r.previous_changes.key?("id") ? "created" : "updated" }
+      r
+    end
+
+    def upsert_menu!(restaurant, h)
+      name = h["name"].to_s.strip
+      m = restaurant.menus.find_or_initialize_by(name: name)
+      m.description = h["description"]
+      m.save!
+      @logs << { scope: "menu", name: m.name, restaurant: restaurant.name, action: m.previous_changes.key?("id") ? "created" : "updated" }
+      m
+    end
+
+    # Cria/atualiza MenuItem (único por restaurante pelo nome)
+    # Define price_cents do item se ainda não tiver (primeira ocorrência).
+    def upsert_menu_item!(restaurant, name, h)
+      item = restaurant.menu_items.find_or_initialize_by(name: name)
+      item.description ||= h["description"]
+      item.available = h.key?("available") ? !!h["available"] : true
+
+      # preço padrão do item (usamos na ausência de preço por menu)
+      if item.price_cents.nil?
+        price_cents = extract_price_cents(h["price"], h["price_cents"])
+        item.price_cents = price_cents if price_cents
+      end
+
+      item.save!
+      @logs << { scope: "menu_item", name: item.name, restaurant: restaurant.name, action: item.previous_changes.key?("id") ? "created" : "updated" }
+      item
+    end
+
+    # Cria o vínculo Menu <-> Item e salva price_cents específico do menu
+    def link_item_to_menu!(menu, item, price, position)
+      mi = MenuItemization.find_or_initialize_by(menu: menu, menu_item: item)
+      mi.position = position
+      mi.price_cents = extract_price_cents(price, nil) || mi.price_cents || item.price_cents || 0
+      mi.save!
+
+      @logs << {
+        scope: "menu_itemization",
+        action: "linked",
+        menu: menu.name,
+        restaurant: menu.restaurant.name,
+        menu_item: item.name,
+        price_cents: mi.price_cents
+      }
+      mi
+    end
+
+    def extract_price_cents(price, price_cents)
+      return price_cents.to_i if price_cents
+      return nil if price.nil?
+      ((price.to_f) * 100).round
+    end
+
+    def log_error(scope, name, errors, menu: nil, restaurant: nil)
+      @errors += 1
+      @logs << { scope:, name:, action: "error", restaurant: restaurant&.name || restaurant, menu: menu&.name || menu, errors: Array(errors) }
+    end
+
+    def result(success)
+      { success: success, errors_count: @errors, logs: @logs }
+    end
+  end
+end

--- a/app/services/importers/restaurant_data_importer.rb
+++ b/app/services/importers/restaurant_data_importer.rb
@@ -15,7 +15,7 @@ module Importers
     def call
       restaurants = Array(@payload["restaurants"])
       if restaurants.empty?
-        log_error("import", nil, ["No restaurants found in payload"])
+        log_error("import", nil, [ "No restaurants found in payload" ])
         return result(false)
       end
 
@@ -26,7 +26,7 @@ module Importers
       result(@errors.zero?)
     rescue => e
       @logger.error(e.full_message)
-      log_error("import", nil, [e.message])
+      log_error("import", nil, [ e.message ])
       result(false)
     end
 
@@ -51,7 +51,7 @@ module Importers
             price = item_json["price"]
 
             if name.blank?
-              log_error("menu_item", nil, ["Missing name"], menu:, restaurant:)
+              log_error("menu_item", nil, [ "Missing name" ], menu:, restaurant:)
               next
             end
 
@@ -76,7 +76,7 @@ module Importers
             rescue ActiveRecord::RecordInvalid => e
               log_error("menu_item", name, e.record.errors.full_messages, menu:, restaurant:)
             rescue => e
-              log_error("menu_item", name, [e.message], menu:, restaurant:)
+              log_error("menu_item", name, [ e.message ], menu:, restaurant:)
             end
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,18 @@
 Rails.application.routes.draw do
-  resources :restaurants, only: [:index, :show, :create] do
-    resources :menus, only: [:index, :create, :show] do
+  resources :restaurants, only: [ :index, :show, :create ] do
+    resources :menus, only: [ :index, :create, :show ] do
       member do
         post   "menu_items/:menu_item_id/link",   to: "menus#link_item",   as: :link_item
         delete "menu_items/:menu_item_id/unlink", to: "menus#unlink_item", as: :unlink_item
       end
     end
 
-    resources :menu_items, only: [:index, :create, :show, :update, :destroy]
+    resources :menu_items, only: [ :index, :create, :show, :update, :destroy ]
   end
 
   # Global Menus/Items (Reading)
-  resources :menus, only: [:index, :show]
-  resources :menu_items, only: [:index, :show]
+  resources :menus, only: [ :index, :show ]
+  resources :menu_items, only: [ :index, :show ]
 
   # Import JSON
   post "/imports/restaurant_json", to: "imports#restaurant_json"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,19 @@
 Rails.application.routes.draw do
-  resources :restaurants, only: [ :index, :show, :create ] do
-    resources :menus, only: [ :index, :create, :show ] do
+  resources :restaurants, only: [:index, :show, :create] do
+    resources :menus, only: [:index, :create, :show] do
       member do
         post   "menu_items/:menu_item_id/link",   to: "menus#link_item",   as: :link_item
         delete "menu_items/:menu_item_id/unlink", to: "menus#unlink_item", as: :unlink_item
       end
     end
 
-    resources :menu_items, only: [ :index, :create, :show, :update, :destroy ]
+    resources :menu_items, only: [:index, :create, :show, :update, :destroy]
   end
 
-  resources :menus, only: [ :index, :show ]
-  resources :menu_items, only: [ :index, :show ]
+  # Global Menus/Items (Reading)
+  resources :menus, only: [:index, :show]
+  resources :menu_items, only: [:index, :show]
+
+  # Import JSON
+  post "/imports/restaurant_json", to: "imports#restaurant_json"
 end

--- a/db/migrate/20251001022935_add_price_cents_to_menu_itemizations.rb
+++ b/db/migrate/20251001022935_add_price_cents_to_menu_itemizations.rb
@@ -1,0 +1,6 @@
+class AddPriceCentsToMenuItemizations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :menu_itemizations, :price_cents, :integer, null: true
+    add_index  :menu_itemizations, :price_cents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_30_235853) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_01_022935) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -20,9 +20,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_30_235853) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "price_cents"
     t.index ["menu_id", "menu_item_id"], name: "index_menu_itemizations_on_menu_id_and_menu_item_id", unique: true
     t.index ["menu_id"], name: "index_menu_itemizations_on_menu_id"
     t.index ["menu_item_id"], name: "index_menu_itemizations_on_menu_item_id"
+    t.index ["price_cents"], name: "index_menu_itemizations_on_price_cents"
   end
 
   create_table "menu_items", force: :cascade do |t|

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,6 +1,6 @@
 namespace :import do
   desc "Importa JSON de restaurantes: rake import:restaurants[path/to/restaurant_data.json]"
-  task :restaurants, [:path] => :environment do |_, args|
+  task :restaurants, [ :path ] => :environment do |_, args|
     path = args[:path] or abort("Provide a JSON file path: rake import:restaurants[path/to/file.json]")
     payload = JSON.parse(File.read(path))
     result = Importers::RestaurantDataImporter.new(payload: payload).call

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,10 @@
+namespace :import do
+  desc "Importa JSON de restaurantes: rake import:restaurants[path/to/restaurant_data.json]"
+  task :restaurants, [:path] => :environment do |_, args|
+    path = args[:path] or abort("Provide a JSON file path: rake import:restaurants[path/to/file.json]")
+    payload = JSON.parse(File.read(path))
+    result = Importers::RestaurantDataImporter.new(payload: payload).call
+    puts JSON.pretty_generate(result)
+    exit(result[:success] ? 0 : 1)
+  end
+end

--- a/spec/fixtures/files/restaurant_data.json
+++ b/spec/fixtures/files/restaurant_data.json
@@ -1,0 +1,43 @@
+{
+  "restaurants": [
+    {
+      "name": "Poppo's Cafe",
+      "menus": [
+        {
+          "name": "lunch",
+          "menu_items": [
+            { "name": "Burger", "price": 9.00 },
+            { "name": "Small Salad", "price": 5.00 }
+          ]
+        },
+        {
+          "name": "dinner",
+          "menu_items": [
+            { "name": "Burger", "price": 15.00 },
+            { "name": "Large Salad", "price": 8.00 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Casa del Poppo",
+      "menus": [
+        {
+          "name": "lunch",
+          "dishes": [
+            { "name": "Chicken Wings", "price": 9.00 },
+            { "name": "Burger", "price": 9.00 },
+            { "name": "Chicken Wings", "price": 9.00 }
+          ]
+        },
+        {
+          "name": "dinner",
+          "dishes": [
+            { "name": "Mega \"Burger\"", "price": 22.00 },
+            { "name": "Lobster Mac & Cheese", "price": 31.00 }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/requests/imports_spec.rb
+++ b/spec/requests/imports_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Imports", type: :request do
+  let(:payload) do
+    JSON.parse(File.read(Rails.root.join("spec/fixtures/files/restaurant_data.json")))
+  end
+
+  it "imports via JSON payload" do
+    post "/imports/restaurant_json", params: { data: payload }
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["success"]).to eq(true)
+    expect(body["logs"]).to be_an(Array)
+  end
+
+  it "imports via file upload" do
+    file = fixture_file_upload("restaurant_data.json", "application/json")
+    post "/imports/restaurant_json", params: { file: file }
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/services/importers/restaurant_data_importer_spec.rb
+++ b/spec/services/importers/restaurant_data_importer_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe Importers::RestaurantDataImporter do
+  let(:payload) do
+    JSON.parse(File.read(Rails.root.join("spec/fixtures/files/restaurant_data.json")))
+  end
+
+  # helper opcional para evitar hardcode do slug
+  def slug_of(name)
+    name.parameterize
+  end
+
+  it "imports restaurants, menus, items and links with per-menu prices" do
+    result = described_class.new(payload: payload).call
+    expect(result[:success]).to eq(true)
+    expect(result[:errors_count]).to be >= 0
+    expect(result[:logs]).to be_an(Array)
+
+    expect(Restaurant.count).to eq(2)
+
+    r1 = Restaurant.find_by(slug: slug_of("Poppo's Cafe"))
+    r2 = Restaurant.find_by(slug: slug_of("Casa del Poppo"))
+    expect(r1).to be_present
+    expect(r2).to be_present
+
+    lunch_r1  = r1.menus.find_by(name: "lunch")
+    dinner_r1 = r1.menus.find_by(name: "dinner")
+    expect(lunch_r1).to be_present
+    expect(dinner_r1).to be_present
+
+    burger_r1 = r1.menu_items.find_by(name: "Burger")
+    expect(burger_r1).to be_present
+
+    mi_lunch  = MenuItemization.find_by(menu: lunch_r1,  menu_item: burger_r1)
+    mi_dinner = MenuItemization.find_by(menu: dinner_r1, menu_item: burger_r1)
+    expect(mi_lunch.price_cents).to eq(900)
+    expect(mi_dinner.price_cents).to eq(1500)
+
+    lunch_r2 = r2.menus.find_by(name: "lunch")
+    wings    = r2.menu_items.find_by(name: "Chicken Wings")
+    expect(wings).to be_present
+
+    links_wings = MenuItemization.where(menu: lunch_r2, menu_item: wings).count
+    expect(links_wings).to eq(1)
+  end
+end


### PR DESCRIPTION
## Changes

### Level 3

**Goal:** JSON import endpoint + conversion tool; per-menu prices.

* **HTTP endpoint** that accepts **JSON** and/or **file upload**:

  * `POST /imports/restaurant_json` with `multipart/form-data` (`file`) **or**
  * `application/json` body `{ "data": { ... } }`
* **Importer service** (`Importers::RestaurantDataImporter`) that:

  * Parses restaurants/menus/items from JSON
  * Accepts items under `menu_items` **or** `dishes`
  * Deduplicates repeated item names in the **same menu** within the payload
  * Upserts **Restaurant**, **Menu**, **MenuItem**
  * **Links items to menus** via `MenuItemization`
  * Returns a **log per item** and an overall `success/fail`
* **Per-menu price support:** add `price_cents` to **`menu_itemizations`** so the same item (e.g., “Burger”) can cost differently in **lunch** vs **dinner**
* **CLI task:** `rake import:restaurants[path/to/restaurant_data.json]`
* **Robust logging & exception handling**
* **Tests:** service spec + endpoint (request) spec